### PR TITLE
Choose Earliest Join Date option

### DIFF
--- a/root/adm/style/acp_user_merge.html
+++ b/root/adm/style/acp_user_merge.html
@@ -46,6 +46,13 @@
 			<dd><input class="text narrow" type="text" id="new_username" name="new_username" value="{NEW_USERNAME}" /></dd>
 			<dd>[ <a href="{U_FIND_NEW_USERNAME}" onclick="find_username(this.href); return false;">{L_FIND_USERNAME}</a> ]</dd>
 		</dl>
+		
+		<dl>
+			<dt><label for="use_earliest">{L_EARLIEST_DATE}:</label><br /><span>{L_EARLIEST_DATE_EXPLAIN}</span></dt>
+			<dd><label><input type="radio" id="use_earliest" name="use_earliest" value="1" checked="checked" class="radio" /> Yes</label>
+				<label><input type="radio" name="use_earliest" value="0" class="radio" /> No</label></dd>
+		</dl>
+
 	</fieldset>
 
 	<fieldset class="submit-buttons">

--- a/root/language/en/mods/lang_user_merge.php
+++ b/root/language/en/mods/lang_user_merge.php
@@ -58,5 +58,7 @@ $lang = array_merge($lang, array(
 	'OLD_USER_EXPLAIN'	=> 'The old user that is to be merged.  Beware, this user will be deleted upon merge.',
 	'NEW_USER'					=> 'New username',
 	'NEW_USER_EXPLAIN'	=> 'The new user that the other user should be merged into.  This user must already exist.',
+	'EARLIEST_DATE'				=> 'Keep earliest join date',
+	'EARLIEST_DATE_EXPLAIN'	=> "Keep the earliest join date from either username otherwise will use the new username's join date.",
 ));
 ?>


### PR DESCRIPTION
This mod adds a radio checkbox to the merge screen to let the admin
select whether to choose the earliest join date of either user or the
default of keeping the join date of the "new" username entered.

Code Testing:

```
1) Option: No
Old_User (earliest joined)
Chooses New_User

2) Option: No
New_User (earliest joined)
Chooses New_User

3) Option: Yes
Old_User (earliest joined)
Chooses Old_User

4) Option: Yes
New_User (earliest joined)
Chooses New_User
```
